### PR TITLE
Let the Unix group "eeprom" access the EEPROM

### DIFF
--- a/debian/overlay/etc/udev/rules.d/10-redpitaya.rules
+++ b/debian/overlay/etc/udev/rules.d/10-redpitaya.rules
@@ -34,7 +34,7 @@ SUBSYSTEM=="spidev", GROUP="spi"
 # I2C
 # /dev/i2c-0 device is already part of the group "i2c"
 # EEPROM
-#SUBSYSTEM=="i2c", DRIVER=="at24", RUN+="/bin/chgrp eeprom /sys%p/eeprom", RUN+="/bin/chmod g=u /sys%p/eeprom"
+SUBSYSTEM=="i2c", DRIVER=="at24", RUN+="/bin/chgrp eeprom /sys%p/eeprom", RUN+="/bin/chmod g=u /sys%p/eeprom"
 
 # UART1
 # /dev/ttyPS1 device is already part of the group "dialout"


### PR DESCRIPTION
One of the great lessons I was taught when starting to learn about computers is “_Don't take the name of root in vain_”. I was thus quite pleased to see that Red Pitaya's Ubuntu image comes with a regular user account belonging to some groups (eeprom, gpio, uio…) that give him access to the interesting hardware.

Access to the EEPROM, however, does not work, but it is needed to run even the simplest program based on the Red Pitaya C API. This program:

```c
#include <rp.h>

int main(void)
{
    rp_Init();
}
```

issues the following error messages on stderr:

```text
[hp_cmn_Init] Error open eeprom: 13                             ← repeated 13 times
[Error:calib_Init] Can't load RP model version. Err: 3
[Error:readParams] Error opening eeprom file.
[Error:calib_InitModel] Cann't read calibration header. Set by default.
[Error] Can't get board model
[Error:rp_AOpinSetValueRaw] Can't get slow DAC bits             ← repeated 4 times
[Error:gen_SetDefaultValues] Can't get fast DAC channels count
[Error:acq_SetDefault] Can't get fast ADC channels count
```

Here, error 13 is the system's `EACCES` (Permission denied), whereas error 3 the API's `RP_HP_ERE` (Error read eeprom).

This pull request fixes this issue by adding a udev rule that grants access to the EEPROM to the eeprom group. Note that the rule was already present in /etc/udev/rules.d/10-redpitaya.rules, only commented-out. I could not find out the rationale for the rule being disabled (`git blame` was of no help).